### PR TITLE
chore: promote format_float_julia_like to public io API

### DIFF
--- a/src/pdft/io/__init__.py
+++ b/src/pdft/io/__init__.py
@@ -15,6 +15,7 @@ from .serialize import (
     basis_hash,
     basis_to_dict,
     dict_to_basis,
+    format_float_julia_like,
     load_basis,
     save_basis,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "compression_stats",
     "dict_to_basis",
     "dict_to_compressed",
+    "format_float_julia_like",
     "load_basis",
     "load_compressed",
     "recover",

--- a/src/pdft/io/serialize.py
+++ b/src/pdft/io/serialize.py
@@ -45,7 +45,7 @@ def _iter_column_major(arr: np.ndarray):
     return np.asarray(arr).flatten(order="F")
 
 
-def _format_float_julia_like(x) -> str:
+def format_float_julia_like(x) -> str:
     """Format a Python float the way Julia's `string(x::Float64)` does.
 
     Python and Julia agree on decimal forms ("1.0", "3.14", "-0.0") and on
@@ -58,7 +58,9 @@ def _format_float_julia_like(x) -> str:
         1e+20          1.0e20         ← Julia drops '+' from positive exponent
         1.5e-07        1.5e-7         ← Julia drops leading zero in exponent
 
-    We produce Julia's form by post-processing Python's `repr`.
+    We produce Julia's form by post-processing Python's `repr`. Used by
+    JSON serialization (basis_to_dict) and by external benchmark code that
+    needs to write Julia-byte-compatible numeric strings.
     """
     # np.float64 reprs as 'np.float64(1.5)'; cast to Python float so repr
     # yields the bare decimal form that Julia uses too.
@@ -104,7 +106,7 @@ def basis_hash(basis: QFTBasis) -> str:
         arr = np.asarray(t)
         for val in _iter_column_major(arr):
             parts.append(
-                f"{_format_float_julia_like(val.real)},{_format_float_julia_like(val.imag)};"
+                f"{format_float_julia_like(val.real)},{format_float_julia_like(val.imag)};"
             )
     canonical = "".join(parts)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
@@ -211,3 +213,8 @@ def load_basis(path: str | Path) -> QFTBasis:
     with p.open("r") as f:
         d: dict[str, Any] = json.load(f)
     return dict_to_basis(d)
+
+
+# Deprecated private alias kept for one release so external code (notably
+# benchmarks/) does not break atomically. Remove in v0.2.0.
+_format_float_julia_like = format_float_julia_like


### PR DESCRIPTION
## Summary
Promotes the internal helper `_format_float_julia_like` (used to write Julia-byte-compatible numeric strings) to a public name `pdft.io.format_float_julia_like`.

## Why
Audit before extracting the `benchmarks/` directory into a standalone repo found exactly one private-symbol coupling: `benchmarks/harness.py:26` does `from pdft.io.serialize import _format_float_julia_like`. Promoting that one symbol removes the only DRY tax on the split.

## What changed
- Rename `_format_float_julia_like` → `format_float_julia_like` in `src/pdft/io/serialize.py` (also internal call site).
- Re-export from `src/pdft/io/__init__.py`.
- Keep `_format_float_julia_like` as a deprecated private alias for one release so existing benchmark code (which still says `_format_float_julia_like`) keeps working until the benchmark repo is extracted. **Remove the alias in v0.2.0.**

## Test plan
- [x] `ruff check src tests` clean
- [x] `pytest -q`: 185/185 pass (incl. parity tests, which exercise the JSON byte format)
- [x] Both names callable: `from pdft.io import format_float_julia_like` and `from pdft.io.serialize import _format_float_julia_like` both work and produce identical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)