### PR TITLE
chore: bump version to 0.2.0; add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: publish
+
+# Builds and publishes pdft to PyPI on every v*.*.* tag push.
+#
+# Uses PyPI Trusted Publishers (OIDC) — NO API token stored in GitHub
+# secrets. To activate: on https://pypi.org/manage/project/pdft/settings/publishing/
+# add a Trusted Publisher with:
+#   PyPI Project Name: pdft
+#   Owner:             zazabap
+#   Repository name:   pdft
+#   Workflow name:     publish.yml
+#   Environment name:  pypi
+#
+# After the first successful publish, future releases are:
+#   git tag v0.2.1 && git push --tags
+#
+# Docs: https://docs.pypi.org/trusted-publishers/
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install build backend
+        run: python -m pip install --upgrade pip build
+      - name: Verify pyproject version matches the git tag
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          file_ver=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$file_ver" ]; then
+            echo "::error::Tag v$tag does not match pyproject.toml version $file_ver"
+            exit 1
+          fi
+      - name: Build
+        run: python -m build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # mandatory for Trusted Publisher OIDC
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pdft"
-version = "0.0.0"
+version = "0.2.0"
 description = "Python port of ParametricDFT.jl: learning parametric quantum Fourier transforms via manifold optimization."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/pdft/__init__.py
+++ b/src/pdft/__init__.py
@@ -41,7 +41,7 @@ if not _os.environ.get("PDFT_DISABLE_COMPILE_CACHE"):
     except OSError:
         pass
 
-__version__ = "0.0.0"
+__version__ = "0.2.0"
 __upstream_ref__ = "nzy1997/ParametricDFT.jl@a201a27e47df2f0f3ab460f83d49b6e5f5d1e9ef"
 
 # Slim public re-export hub: most-used names only. Anything else: import


### PR DESCRIPTION
## What this does
- Sync \`pyproject.toml\` \`version\` and \`src/pdft/__init__.py\` \`__version__\` with the existing \`v0.2.0\` git tag (both were stale at \`"0.0.0"\`, placeholder from the original Phase 1 scaffold). Once merged, \`pdft >= 0.2.0\` resolves cleanly from \`pdft-benchmarks\` (no more \`--no-deps\`).
- Add \`.github/workflows/publish.yml\` that builds sdist + wheel on every \`v*.*.*\` tag push and uploads via **PyPI Trusted Publisher (OIDC)** — no long-lived API token in GitHub secrets.

## Local build verified
\`\`\`
$ python -m build
Successfully built pdft-0.2.0.tar.gz and pdft-0.2.0-py3-none-any.whl
\`\`\`

## Before this can actually publish, you need to do (one-time, off-GitHub):

1. **Verify \`pdft\` is available on PyPI.** Visit https://pypi.org/project/pdft/ — if it 404s, the name is free. If it's taken (it might be — \`pdft\` is a short generic acronym), pick another name (\`parametric-dft\`?) and update \`name = "..."\` in \`pyproject.toml\` before merging.
2. **Configure a PyPI Trusted Publisher.** On https://pypi.org/manage/account/publishing/ add a *pending* publisher (because the project doesn't exist yet) with:
   - PyPI Project Name: \`pdft\` (or whatever you chose in step 1)
   - Owner: \`zazabap\`
   - Repository: \`pdft\`
   - Workflow filename: \`publish.yml\`
   - Environment name: \`pypi\`
3. **Create the GitHub Environment** \`pypi\` on https://github.com/zazabap/pdft/settings/environments — empty config is fine, but the environment must exist for the workflow's \`environment: pypi\` to find it.

After steps 1–3, merging this PR + pushing the existing \`v0.2.0\` tag (or a fresh \`v0.2.1\`) will trigger the workflow and publish.

## Test plan
- [x] \`python -m build\` produces correct artifacts locally
- [x] Workflow syntax validated by \`gh workflow view publish.yml\` after push (will show as \"this workflow has not been run\" until a tag is pushed)
- [ ] First publish — manual trigger by tag push after PyPI Trusted Publisher is configured

## Important note on \`v0.2.0\` re-publish
The git tag \`v0.2.0\` already exists. After merging this PR, the new commit on \`main\` will NOT be at the same SHA as the existing tag. Two options:
- **A.** Move the tag to the new commit (\`git tag -f v0.2.0 <new-sha> && git push -f --tags\`) — destructive, only safe because the tag has never been published.
- **B.** Skip \`v0.2.0\` and publish as \`v0.2.1\` after merge — cleaner.

Recommend (B).