### PR TITLE
feat(circuit): stepped tensordot for circuits beyond the 52-label pool

### DIFF
--- a/src/pdft/circuit/builder.py
+++ b/src/pdft/circuit/builder.py
@@ -167,6 +167,83 @@ def build_circuit_einsum(
     return subscripts, tensor_list, tensor_shapes
 
 
+def _axis_of_qubit(q: int, m: int, n: int) -> int:
+    """Map a 1-indexed qubit number to its position in the (2,)*N reshape of pic.
+
+    Yao's little-endian convention (matching `build_circuit_einsum`'s
+    `pic_labels` ordering): qubit `m` maps to axis 0, qubit `m-1` to axis 1,
+    …, qubit 1 to axis m-1, qubit `m+n` to axis m, …, qubit `m+1` to axis
+    m+n-1.
+    """
+    if 1 <= q <= m:
+        return m - q
+    if m + 1 <= q <= m + n:
+        return m + (m + n - q)
+    raise ValueError(f"qubit index {q} out of range (1..{m + n})")
+
+
+def _stepped_apply(
+    program: list[tuple[str, tuple[int, ...]]],
+    tensor_index: list[int],
+    operands: tuple,
+    *,
+    m: int,
+    n: int,
+    inverse: bool,
+) -> Array:
+    """Apply gate program to pic via per-gate `jnp.tensordot` calls.
+
+    operands = (*tensors, pic) where pic has shape (2,) * (m+n) and tensors
+    is the operand list passed to the closure (sorted Hadamard-first by
+    `compile_circuit`, matching the convention of the legacy big-einsum
+    path so saved checkpoints load with the same axis order).
+
+    `tensor_index[i]` maps program step i (in temporal order) to its index
+    in the operand `tensors` tuple.
+    """
+    *tensors, pic = operands
+    for i, (kind, qubits) in enumerate(program):
+        T = tensors[tensor_index[i]]
+        if kind == "H":
+            (q,) = qubits
+            ax = _axis_of_qubit(q, m, n)
+            # H[out, in] · pic[..., ax=in, ...] -> pic[..., ax=out, ...]
+            pic = jnp.tensordot(T, pic, axes=[[1], [ax]])
+            pic = jnp.moveaxis(pic, 0, ax)
+        elif kind == "CP":
+            q_ctrl, q_tgt = qubits
+            ax_c = _axis_of_qubit(q_ctrl, m, n)
+            ax_t = _axis_of_qubit(q_tgt, m, n)
+            # T[c, t] is the diagonal of CP. pic *= T broadcast onto (ax_c, ax_t).
+            broadcast_shape = [1] * pic.ndim
+            broadcast_shape[ax_c] = 2
+            broadcast_shape[ax_t] = 2
+            # T's axis 0 should land at ax_c, axis 1 at ax_t. If ax_c < ax_t,
+            # the natural reshape works; if ax_c > ax_t, we transpose first
+            # so the smaller dimension index sees T's first axis.
+            T_oriented = T if ax_c < ax_t else T.T
+            pic = pic * T_oriented.reshape(broadcast_shape)
+        elif kind == "U4":
+            q_ctrl, q_tgt = qubits
+            ax_c = _axis_of_qubit(q_ctrl, m, n)
+            ax_t = _axis_of_qubit(q_tgt, m, n)
+            # Forward: T[oc, ot, ic, it] · pic[..., ax_c=ic, ax_t=it, ...]
+            #          -> pic[..., ax_c=oc, ax_t=ot, ...]
+            # Inverse (transpose, not adjoint): T[oc, ot, ic, it]
+            #          · pic[..., ax_c=oc, ax_t=ot, ...]
+            #          -> pic[..., ax_c=ic, ax_t=it, ...]
+            # The conjugate flip for the true unitary inverse is applied by
+            # the caller (loss._scalar_loss conjugates tensors before
+            # calling the inverse closure), matching the legacy
+            # build_circuit_einsum behaviour.
+            contract_axes = [[0, 1], [ax_c, ax_t]] if inverse else [[2, 3], [ax_c, ax_t]]
+            pic = jnp.tensordot(T, pic, axes=contract_axes)
+            pic = jnp.moveaxis(pic, [0, 1], [ax_c, ax_t])
+        else:
+            raise AssertionError(f"unknown gate kind: {kind}")
+    return pic
+
+
 def compile_circuit(
     gates: list[Gate],
     m: int,
@@ -174,12 +251,61 @@ def compile_circuit(
     *,
     inverse: bool,
 ) -> tuple[Callable[..., Array], list[Array]]:
-    """High-level entry: build subscripts and jit-compile the einsum."""
-    from .cache import optimize_code_cached
+    """Build a JIT-compiled stepped circuit closure.
 
-    subscripts, tensors, shapes = build_circuit_einsum(gates, m, n, inverse=inverse)
-    code = optimize_code_cached(subscripts, *shapes)
-    return code, tensors
+    Returns ``(code, tensors)`` where ``code(*tensors, pic_reshaped)``
+    applies the gates one at a time via :func:`jnp.tensordot`, recycling
+    contraction labels across steps so the 52-character a-zA-Z label pool
+    of the legacy single-einsum path is never reached. Each step consumes
+    at most ~22 wire labels regardless of circuit size.
+
+    The returned ``tensors`` list preserves the Hadamard-first sort applied
+    by the legacy builder, so saved trained checkpoints (which serialize
+    tensors in this order) continue to load consistently.
+    """
+    n_gates = len(gates)
+    program: list[tuple[str, tuple[int, ...]]] = [
+        (g["kind"], g["qubits"]) for g in gates
+    ]
+    tensor_list: list[Array] = [g["tensor"] for g in gates]
+
+    # Hadamard-first sort — preserves the legacy convention for the
+    # returned tensor list. `perm[i]` is the original (temporal) gate index
+    # of the i-th sorted slot, so `sorted_tensors[i] = original[perm[i]]`.
+    import numpy as _np
+
+    H_np = _np.asarray(HADAMARD)
+
+    def _is_hadamard(t):
+        a = _np.asarray(t)
+        return a.shape == (2, 2) and _np.allclose(a, H_np, atol=1e-12)
+
+    is_not_hadamard = [not _is_hadamard(t) for t in tensor_list]
+    perm = sorted(range(n_gates), key=lambda i: is_not_hadamard[i])
+    sorted_tensors = [tensor_list[i] for i in perm]
+
+    # Map temporal gate index → position in the sorted operand tuple.
+    # `temporal_to_sorted[j] = i` such that perm[i] = j.
+    temporal_to_sorted = [0] * n_gates
+    for sorted_pos, original_idx in enumerate(perm):
+        temporal_to_sorted[original_idx] = sorted_pos
+
+    if inverse:
+        # Apply gates in reverse temporal order. tensor_index aligns with
+        # the reversed program: program_step[i] needs the tensor for the
+        # ORIGINAL gate at index (n_gates-1-i).
+        program = list(reversed(program))
+        tensor_index = [temporal_to_sorted[n_gates - 1 - i] for i in range(n_gates)]
+    else:
+        tensor_index = [temporal_to_sorted[i] for i in range(n_gates)]
+
+    @jax.jit
+    def code(*operands):
+        return _stepped_apply(
+            program, tensor_index, operands, m=m, n=n, inverse=inverse,
+        )
+
+    return code, sorted_tensors
 
 
 def apply_circuit(

--- a/tests/circuit/test_high_qubit_circuit.py
+++ b/tests/circuit/test_high_qubit_circuit.py
@@ -1,0 +1,62 @@
+"""Regression tests for circuits whose flat-einsum representation would
+exceed the 52-character a-zA-Z label pool.
+
+The pre-fix `build_circuit_einsum` allocates a fresh label per Hadamard
+output and two fresh labels per U4 output. RealRichBasis at inner_m=5,
+inner_n=5 emits 2(m + m²) = 60 fresh labels — over the limit and raising
+ValueError at construction. The stepped-contraction implementation
+applies one gate per `jnp.tensordot`, recycling labels across steps so
+the limit never bites.
+
+These tests pin both:
+  - construction succeeds at inner_m=5
+  - the forward+inverse roundtrip returns the input image to machine
+    precision (a 32×32 image at m=n=5)
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from pdft import RealRichBasis, RichBasis
+
+
+@pytest.mark.parametrize("BasisCls", [RichBasis, RealRichBasis])
+def test_basis_constructs_at_m5(BasisCls):
+    """Construction must succeed at m=n=5 (10 qubits per block, 60 fresh labels)."""
+    basis = BasisCls(m=5, n=5)
+    assert basis.m == 5
+    assert basis.n == 5
+
+
+@pytest.mark.parametrize("BasisCls", [RichBasis, RealRichBasis])
+def test_basis_forward_inverse_roundtrip_at_m5(BasisCls):
+    """Forward then inverse on the initial (untrained) basis must reproduce the input.
+
+    At step 0 the basis is initialised to a known unitary (QFT-like for RichBasis,
+    Walsh-Hadamard ⊗ identity for RealRichBasis), so U U^{-1} = I exactly.
+    """
+    rng = np.random.default_rng(0)
+    pic = jnp.asarray(rng.normal(size=(32, 32)).astype(np.float64))
+
+    basis = BasisCls(m=5, n=5)
+    transformed = basis.forward_transform(pic)
+    recovered = basis.inverse_transform(transformed)
+
+    np.testing.assert_allclose(np.real(recovered), np.asarray(pic), atol=1e-9)
+
+
+@pytest.mark.parametrize("BasisCls", [RichBasis, RealRichBasis])
+def test_basis_forward_preserves_norm_at_m5(BasisCls):
+    """Unitary forward circuits must preserve the Frobenius norm of the input."""
+    rng = np.random.default_rng(1)
+    pic = jnp.asarray(rng.normal(size=(32, 32)).astype(np.float64))
+
+    basis = BasisCls(m=5, n=5)
+    transformed = basis.forward_transform(pic)
+
+    norm_in = float(jnp.linalg.norm(pic))
+    norm_out = float(jnp.linalg.norm(transformed))
+    np.testing.assert_allclose(norm_out, norm_in, rtol=1e-10)

--- a/tests/circuit/test_legacy_builder.py
+++ b/tests/circuit/test_legacy_builder.py
@@ -1,0 +1,146 @@
+"""Tests for the legacy `build_circuit_einsum` (single-string-einsum builder).
+
+`compile_circuit` no longer routes through `build_circuit_einsum` — it uses
+the stepped-tensordot path that handles circuits beyond the 52-character
+label pool. The legacy function is retained as public API (re-exported
+from `pdft.circuit`) so external consumers depending on the
+`(subscripts, tensors, shapes)` triple keep working.
+
+These tests exercise the legacy function directly and pin three things:
+  - subscripts and shape lists are well-formed for each gate kind,
+  - the Hadamard-first operand sort is preserved, and
+  - the resulting einsum, when contracted, agrees with `compile_circuit`
+    on a small circuit (no overlap with the label-pool limit).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from pdft.circuit import build_circuit_einsum, compile_circuit
+from pdft.circuit.builder import (
+    HADAMARD,
+    Gate,
+    controlled_phase_diag,
+    u4_from_phase,
+)
+
+
+def _h_gate(q: int) -> Gate:
+    return Gate(kind="H", qubits=(q,), tensor=HADAMARD, phase=0.0)
+
+
+def _cp_gate(q_ctrl: int, q_tgt: int, phi: float = 0.5) -> Gate:
+    return Gate(kind="CP", qubits=(q_ctrl, q_tgt), tensor=controlled_phase_diag(phi), phase=phi)
+
+
+def _u4_gate(q_ctrl: int, q_tgt: int, phi: float = 0.5) -> Gate:
+    return Gate(kind="U4", qubits=(q_ctrl, q_tgt), tensor=u4_from_phase(phi), phase=phi)
+
+
+def test_legacy_build_h_only_circuit_subscripts_and_shapes():
+    """Single Hadamard on qubit 1 of a 1+1-qubit circuit."""
+    gates = [_h_gate(1)]
+    subs, tensors, shapes = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    assert "->" in subs
+    # One H tensor + the pic operand
+    assert len(tensors) == 1
+    assert len(shapes) == 2
+    # H tensor shape (2,2); pic shape (2,2) for m=n=1
+    assert shapes[0] == (2, 2)
+    assert shapes[1] == (2, 2)
+
+
+def test_legacy_build_cp_does_not_introduce_new_labels():
+    """CP gate shares its operands' labels — no fresh labels emitted."""
+    gates = [_h_gate(1), _h_gate(2), _cp_gate(1, 2)]
+    subs, tensors, shapes = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    # 3 gate tensors + 1 pic operand
+    assert len(tensors) == 3
+    # All three gate tensors are 2x2; pic is 2x2
+    assert all(s == (2, 2) for s in shapes)
+
+
+def test_legacy_build_u4_emits_two_fresh_labels():
+    """U4 gate has shape (2,2,2,2) and emits two new wire labels."""
+    gates = [_u4_gate(1, 2)]
+    subs, tensors, shapes = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    assert shapes[0] == (2, 2, 2, 2)
+    # Labels in the U4's subscript should be 4 distinct chars
+    lhs = subs.split("->")[0]
+    u4_subscripts = lhs.split(",")[0]
+    assert len(u4_subscripts) == 4
+    assert len(set(u4_subscripts)) == 4
+
+
+def test_legacy_build_inverse_swaps_input_and_output_labels():
+    """inverse=True routes pic in via the gates' OUTPUT labels and out via INPUTS."""
+    gates = [_h_gate(1)]
+    subs_fwd, _, _ = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    subs_inv, _, _ = build_circuit_einsum(gates, m=1, n=1, inverse=True)
+    # Forward: gate[out, in], pic[in] -> [out].   inverse: gate[out, in], pic[out] -> [in].
+    fwd_lhs, fwd_rhs = subs_fwd.split("->")
+    inv_lhs, inv_rhs = subs_inv.split("->")
+    fwd_pic_lbl = fwd_lhs.split(",")[-1]
+    inv_pic_lbl = inv_lhs.split(",")[-1]
+    # Forward output label == inverse input (pic) label, and vice versa.
+    assert fwd_pic_lbl == inv_rhs
+    assert fwd_rhs == inv_pic_lbl
+
+
+def test_legacy_build_hadamard_first_sort():
+    """Hadamards must come first in the operand list regardless of gate-list order."""
+    # Interleaved: U4, H, U4, H
+    gates = [_u4_gate(1, 2), _h_gate(1), _u4_gate(1, 2), _h_gate(2)]
+    _, tensors, _ = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    # First two operands should be the H tensors (shape (2,2)), last two U4 (shape (2,2,2,2)).
+    assert tensors[0].shape == (2, 2)
+    assert tensors[1].shape == (2, 2)
+    assert tensors[2].shape == (2, 2, 2, 2)
+    assert tensors[3].shape == (2, 2, 2, 2)
+
+
+def test_legacy_build_qubit_out_of_range_raises():
+    """Validation: qubit index 0 (1-indexed convention) and > m+n raise ValueError."""
+    # The Hadamard on qubit 0 hits a KeyError at wire_state[q]; the explicit
+    # check is on label-pool exhaustion. Instead probe the >m+n branch via
+    # an out-of-range qubit on a 1-qubit circuit.
+    gates = [_h_gate(99)]
+    with pytest.raises(KeyError):
+        build_circuit_einsum(gates, m=1, n=1, inverse=False)
+
+
+def test_legacy_build_label_pool_exhaustion_raises():
+    """Construct enough U4 gates to overflow the 52-label pool."""
+    # 12 U4 gates each emit 2 fresh labels = 24 fresh from U4 plus 4 input
+    # labels. Add Hadamards to push past 52.
+    gates: list[Gate] = []
+    # Need to emit > 52 fresh labels. Each H on a wire emits 1, each U4 emits 2.
+    # 30 H gates on 4 wires (cycling) = 30 fresh. Plus 4 input + 12 H more = 46.
+    # Easier: use 30 U4 gates between qubits 1-2 = 60 fresh. Plus 4 inputs.
+    for _ in range(30):
+        gates.append(_u4_gate(1, 2))
+    with pytest.raises(ValueError, match="too many qubits"):
+        build_circuit_einsum(gates, m=2, n=2, inverse=False)
+
+
+def test_legacy_build_matches_compile_circuit_numerically():
+    """For a small circuit, the legacy big-einsum and the new stepped path
+    must produce the same forward output to machine precision."""
+    from pdft.circuit.cache import optimize_code_cached
+
+    gates = [_h_gate(1), _h_gate(2), _cp_gate(1, 2, phi=0.7), _u4_gate(1, 2, phi=0.3)]
+    subs, tensors_legacy, shapes = build_circuit_einsum(gates, m=1, n=1, inverse=False)
+    legacy_code = optimize_code_cached(subs, *shapes)
+    code_new, tensors_new = compile_circuit(gates, m=1, n=1, inverse=False)
+
+    rng = np.random.default_rng(42)
+    pic_2d = jnp.asarray(rng.normal(size=(2, 2)).astype(np.float64))
+    pic = pic_2d.astype(jnp.complex128).reshape((2, 2))
+
+    out_legacy = legacy_code(*tensors_legacy, pic)
+    out_new = code_new(*tensors_new, pic)
+
+    np.testing.assert_allclose(np.asarray(out_legacy), np.asarray(out_new), atol=1e-12)


### PR DESCRIPTION
## Summary

The legacy `build_circuit_einsum` allocates a fresh single-character einsum label for each Hadamard output and two for each `U4` output, drawing from a 52-label `a-zA-Z` pool. **RealRichBasis** and **RichBasis** at `inner_m=5, inner_n=5` emit `2(m + m²) = 60` fresh labels and crash at construction with `ValueError: too many qubits: need > 52 einsum labels`.

This PR replaces `compile_circuit`'s internals with a **stepped contraction**: each gate is applied with one `jnp.tensordot` (Hadamard, U4) or a broadcast multiply (CP, diagonal). Labels are recycled across steps; the per-step label budget is at most ~22 regardless of total circuit size.

## External surface preserved

- `compile_circuit(gates, m, n, *, inverse) -> (code, tensors)` signature unchanged.
- `code(*tensors, pic)` call signature unchanged.
- Returned `tensors` retain the **Hadamard-first sort**, so saved trained checkpoints keep loading with the same axis order.
- `build_circuit_einsum` is kept and still works for circuits within the 52-label budget (re-exported from `pdft.circuit`).

## Inverse semantics

Match the legacy einsum exactly: the "inverse" closure computes the **transpose** of the forward unitary, not the conjugate transpose. The conjugate flip for the true unitary inverse is applied by callers (`loss._scalar_loss` conjugates tensors before invoking the inverse closure).

## Test plan

- [x] All 191 existing pdft tests pass — including the parity tests against Julia goldens, confirming numerical equivalence with the legacy single-einsum path.
- [x] New `tests/circuit/test_high_qubit_circuit.py` (6 tests):
  - RichBasis and RealRichBasis at `m=n=5` construct without raising.
  - Forward+inverse roundtrip on a 32×32 image returns the input to ≤1e-9 absolute error.
  - Frobenius norm preserved through forward (unitarity check).
- [x] `pdft-benchmarks` immediately sees the fix via `pip install -e` — `rich_32` and `real_rich_32` factories now construct on DIV2K geometry (m=n=8), unblocking the b=32 cells of the block-size sweep.

## Motivation

This is the prerequisite for the b=32 row of the block-size sweep in the companion `pdft-benchmarks` paper appendix (`feat/block-size-sweep-trained` branch there). With this fix, the trained sweep grid `{blocked, rich, real_rich} × {4, 8, 16, 32}` is fully buildable on DIV2K — previously only `blocked_32` (which uses QFTBasis, no `U4`) could train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)