### PR TITLE
fix(circuit): swap H-gate contraction leg in inverse path

### DIFF
--- a/src/pdft/circuit/builder.py
+++ b/src/pdft/circuit/builder.py
@@ -207,8 +207,17 @@ def _stepped_apply(
         if kind == "H":
             (q,) = qubits
             ax = _axis_of_qubit(q, m, n)
-            # H[out, in] · pic[..., ax=in, ...] -> pic[..., ax=out, ...]
-            pic = jnp.tensordot(T, pic, axes=[[1], [ax]])
+            # Forward: H[out, in] · pic[..., ax=in, ...] -> pic[..., ax=out, ...]
+            #   contract on T's axis 1 (the "in" leg).
+            # Inverse: apply the transpose of T. Combined with the caller's
+            #   conj(T) (loss._scalar_loss conjugates tensors before passing
+            #   them to the inverse closure), this realises the true adjoint
+            #   T† = conj(T.T). For symmetric H this collapses to conj(T),
+            #   but for trained / non-symmetric H tensors the leg-swap is
+            #   essential — without it the round-trip T† T x ≠ x. The U4
+            #   handler below uses the same forward/inverse axis convention.
+            contract_in = 0 if inverse else 1
+            pic = jnp.tensordot(T, pic, axes=[[contract_in], [ax]])
             pic = jnp.moveaxis(pic, 0, ax)
         elif kind == "CP":
             q_ctrl, q_tgt = qubits

--- a/tests/circuit/test_h_inverse_leg_swap.py
+++ b/tests/circuit/test_h_inverse_leg_swap.py
@@ -1,0 +1,142 @@
+"""Regression test for the H-gate inverse leg-swap bug.
+
+The stepped-tensordot rewrite of `compile_circuit` (commit
+`feat(circuit): stepped tensordot for circuits beyond the 52-label pool`)
+forgot to swap the contracted leg of the Hadamard tensor when
+``inverse=True``. Combined with `loss._scalar_loss`'s convention of
+passing ``conj(tensors)`` to the inverse closure, this means the
+inverse path applies ``conj(H)`` instead of the proper adjoint
+``conj(H.T) = H†``.
+
+For the default symmetric Hadamard (``[[1, 1], [1, -1]] / sqrt 2``),
+``conj(H) = H = H†`` so the bug is invisible. For a *trained* (and
+therefore non-symmetric) Hadamard the bug breaks the round-trip:
+``T† T x ≠ x``. The U4 gate handler in the same function does the
+leg-swap correctly already; this test pins the equivalent contract for
+the H gate.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import pdft
+
+
+def _non_symmetric_unitary(seed: int = 0) -> jnp.ndarray:
+    """A 2x2 unitary that is NOT real-symmetric (so conj ≠ adjoint).
+
+    Built as exp(i * theta * X) for a Hermitian X with non-zero off-diagonal
+    imag parts. The result is unitary by construction and demonstrably
+    non-Hermitian and non-symmetric.
+    """
+    rng = np.random.default_rng(seed)
+    # Random Hermitian generator with complex off-diagonal
+    g = rng.normal(size=(2, 2)) + 1j * rng.normal(size=(2, 2))
+    H = (g + g.conj().T) / 2  # Hermitian
+    # exp(i * H) is unitary; for a non-trivial H it is non-symmetric in general
+    eigvals, eigvecs = np.linalg.eigh(H)
+    U = eigvecs @ np.diag(np.exp(1j * eigvals)) @ eigvecs.conj().T
+    return jnp.asarray(U, dtype=jnp.complex128)
+
+
+def test_qft_inverse_round_trip_with_non_symmetric_h():
+    """Round-trip ``T† T x = x`` must hold to machine precision when one or
+    more Hadamard tensors are non-symmetric unitaries (the situation that
+    arises after Riemannian-Adam training perturbs the gates off the
+    initial real-symmetric H).
+    """
+    m, n = 3, 3
+    basis = pdft.QFTBasis(m=m, n=n)
+
+    # Replace the FIRST Hadamard tensor with a non-symmetric unitary.
+    # QFTBasis sorts tensors Hadamards-first, so tensors[0..m+n-1] are H slots.
+    perturbed = list(basis.tensors)
+    U_nonsym = _non_symmetric_unitary(seed=42)
+    perturbed[0] = U_nonsym
+
+    # Sanity: the replacement is unitary but not symmetric.
+    assert np.allclose(
+        np.asarray(U_nonsym) @ np.asarray(U_nonsym).conj().T, np.eye(2), atol=1e-12
+    ), "test setup error: replacement matrix must be unitary"
+    assert not np.allclose(
+        np.asarray(U_nonsym), np.asarray(U_nonsym).T, atol=1e-6
+    ), "test setup error: replacement matrix must be non-symmetric"
+
+    perturbed_basis = pdft.QFTBasis(m=m, n=n, tensors=perturbed)
+
+    rng = np.random.default_rng(0)
+    x = jnp.asarray(
+        rng.standard_normal((2**m, 2**n)) + 1j * rng.standard_normal((2**m, 2**n)),
+        dtype=jnp.complex128,
+    )
+
+    # Forward must preserve norm (operator is unitary).
+    Tx = perturbed_basis.forward_transform(x)
+    np.testing.assert_allclose(
+        float(jnp.sum(jnp.abs(Tx) ** 2)),
+        float(jnp.sum(jnp.abs(x) ** 2)),
+        rtol=1e-10,
+        err_msg="forward operator is not norm-preserving",
+    )
+
+    # Round-trip must recover x to machine precision.
+    rt = perturbed_basis.inverse_transform(Tx)
+    np.testing.assert_allclose(
+        np.asarray(rt),
+        np.asarray(x),
+        atol=1e-10,
+        err_msg="round-trip T† T x != x — H-gate inverse leg-swap bug",
+    )
+
+
+def test_blocked_inverse_round_trip_with_non_symmetric_h():
+    """Same regression for BlockedBasis(QFTBasis, ...) — this is the path
+    actually hit by the trained_blocked_8 cell whose val loss the bug
+    inflated by ~12x.
+    """
+    inner = pdft.QFTBasis(m=3, n=3)
+    perturbed = list(inner.tensors)
+    perturbed[0] = _non_symmetric_unitary(seed=7)
+    perturbed_inner = pdft.QFTBasis(m=3, n=3, tensors=perturbed)
+
+    blocked = pdft.BlockedBasis(inner=perturbed_inner, block_log_m=2, block_log_n=2)
+
+    rng = np.random.default_rng(1)
+    side = 2 ** blocked.m
+    x = jnp.asarray(
+        rng.standard_normal((side, side)) + 1j * rng.standard_normal((side, side)),
+        dtype=jnp.complex128,
+    )
+
+    Tx = blocked.forward_transform(x)
+    np.testing.assert_allclose(
+        float(jnp.sum(jnp.abs(Tx) ** 2)),
+        float(jnp.sum(jnp.abs(x) ** 2)),
+        rtol=1e-10,
+    )
+
+    rt = blocked.inverse_transform(Tx)
+    np.testing.assert_allclose(
+        np.asarray(rt), np.asarray(x), atol=1e-10,
+        err_msg="BlockedBasis round-trip broken — H-gate inverse leg-swap bug",
+    )
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+def test_qft_inverse_round_trip_with_non_symmetric_h_random_seeds(seed: int):
+    """Robustness: hold across multiple random non-symmetric H replacements."""
+    basis = pdft.QFTBasis(m=2, n=2)
+    perturbed = list(basis.tensors)
+    perturbed[0] = _non_symmetric_unitary(seed=seed)
+    perturbed_basis = pdft.QFTBasis(m=2, n=2, tensors=perturbed)
+
+    rng = np.random.default_rng(seed)
+    x = jnp.asarray(
+        rng.standard_normal((4, 4)) + 1j * rng.standard_normal((4, 4)),
+        dtype=jnp.complex128,
+    )
+    rt = perturbed_basis.inverse_transform(perturbed_basis.forward_transform(x))
+    np.testing.assert_allclose(np.asarray(rt), np.asarray(x), atol=1e-10)


### PR DESCRIPTION
## Summary

The stepped-tensordot rewrite of `compile_circuit` (#15) ported the U4 gate's forward/inverse leg-swap correctly:

```python
contract_axes = [[0, 1], [ax_c, ax_t]] if inverse else [[2, 3], [ax_c, ax_t]]
```

but forgot the analogous swap for the H gate handler — both forward and inverse used the same `axes=[[1], [ax]]`. Combined with the convention in `loss._scalar_loss` of passing `conj(tensors)` to the inverse closure, this means the inverse path applies `conj(H)` instead of the proper adjoint `conj(H.T) = H†`.

For the **default real-symmetric Hadamard** (`[[1, 1], [1, -1]] / sqrt 2`), `conj(H) = H = H†`, so the bug is **invisible at fresh init** and against the existing high-qubit round-trip tests (which only test untrained bases). After Riemannian-Adam training, the H tensors drift to a non-symmetric still-unitary form and the bug manifests as a broken round-trip.

## Impact

Measured on a real trained checkpoint (`trained_blocked_8.json` from pdft-benchmarks, trained May 7 against parent commit `c39771c`):

| pdft commit | round-trip `‖T⁻¹(T(x)) − x‖²` (random complex 256×256) | val loss on the same 75-image split |
|---|---:|---:|
| `c39771c` (parent of #15) | **2.7e-22** (machine zero) | **152.9** |
| `c9119d9` (after #15) | 1.95e+04 | 1582 (12× too high) |
| `c9119d9 + this fix` | **2.7e-22** | **152.9** |

The forward operator is still norm-preserving in all cases (`‖T(x)‖² = ‖x‖²` exactly); only the inverse path is broken. So the bug **silently inflates loss values for any downstream consumer** of `loss._scalar_loss` whenever H tensors are non-symmetric, which is the typical post-training state.

## The fix

```python
# src/pdft/circuit/builder.py — _stepped_apply, H-gate branch
if kind == "H":
    (q,) = qubits
    ax = _axis_of_qubit(q, m, n)
    contract_in = 0 if inverse else 1   # <-- new: swap leg on inverse
    pic = jnp.tensordot(T, pic, axes=[[contract_in], [ax]])
    pic = jnp.moveaxis(pic, 0, ax)
```

Combined with the caller's `conj(T)`, this realises `T† = conj(T.T)` for arbitrary unitary `T`. Same convention the U4 handler already uses in this file.

## Regression test

`tests/circuit/test_h_inverse_leg_swap.py` (new file):
- Replaces one of `QFTBasis(3,3)`'s Hadamard tensors with a non-symmetric unitary (`exp(i · H_random)` for random Hermitian H), then asserts forward + inverse recovers the input to `atol=1e-10`.
- Same test for `BlockedBasis(QFTBasis(3,3), block_log=2,2)` — the path that surfaced the bug in pdft-benchmarks.
- 5 random non-symmetric H replacements at `QFT(2,2)`.

**Before fix**: 7 failures (round-trip error ~1e+04).
**After fix**: 7 pass.

## Test plan

- [x] New regression test passes (7 cases)
- [x] All 199 existing tests continue to pass (`pytest tests/`)
- [x] `pytest tests/ -q` reports `206 passed` (199 existing + 7 new)
- [x] Round-trip on a real trained checkpoint drops from `1.95e+04` to `2.7e-22`
- [x] Val loss matches pre-#15 pdft to numerical precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)