### PR TITLE
[codex] feat(loss): add MSELoss extra loss hook

### DIFF
--- a/src/pdft/loss.py
+++ b/src/pdft/loss.py
@@ -120,7 +120,13 @@ def _scalar_loss(
         truncated = topk_truncate(pred, loss.k)
         conj_tensors = [jnp.conj(t) for t in tensors]  # type: ignore[arg-type]
         reconstructed = _apply_circuit(conj_tensors, inverse_code, m, n, truncated)  # type: ignore[arg-type]
-        return jnp.sum(jnp.abs(target - reconstructed) ** 2)
+        base = jnp.sum(jnp.abs(target - reconstructed) ** 2)
+        # Optional hook for MSELoss subclasses that add regularizers or
+        # auxiliary scalar terms while preserving vanilla MSELoss behavior.
+        extra_fn = getattr(loss, "_extra_loss", None)
+        if extra_fn is not None:
+            return base + extra_fn(tensors)
+        return base
     raise TypeError(f"unsupported loss type: {type(loss).__name__}")
 
 

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -1,7 +1,10 @@
+from dataclasses import dataclass
+
 import jax.numpy as jnp
 import pytest
 
-from pdft.loss import L1Norm, MSELoss, topk_truncate
+from pdft.bases.circuit.qft import qft_code
+from pdft.loss import L1Norm, MSELoss, loss_function, topk_truncate
 
 
 def test_l1norm_is_stateless():
@@ -43,3 +46,48 @@ def test_topk_truncate_k_larger_than_length_clamps():
     x = jnp.array([[1.0 + 0j, 2.0]])
     out = topk_truncate(x, k=10)
     assert jnp.allclose(out, x)
+
+
+def test_mseloss_no_extra_loss_unchanged():
+    m, n = 2, 2
+    code, tensors = qft_code(m, n)
+    inv_code, _ = qft_code(m, n, inverse=True)
+    pic = jnp.ones((4, 4), dtype=jnp.complex128) / 4.0
+
+    base_loss = float(loss_function(tensors, m, n, code, pic, MSELoss(k=1), inverse_code=inv_code))
+
+    assert base_loss == base_loss
+
+
+def test_mseloss_extra_loss_hook_adds_term():
+    @dataclass(frozen=True)
+    class WithExtra(MSELoss):
+        def _extra_loss(self, tensors):
+            return jnp.asarray(7.0, dtype=jnp.float64)
+
+    m, n = 2, 2
+    code, tensors = qft_code(m, n)
+    inv_code, _ = qft_code(m, n, inverse=True)
+    pic = jnp.ones((4, 4), dtype=jnp.complex128) / 4.0
+
+    base_loss = float(loss_function(tensors, m, n, code, pic, MSELoss(k=1), inverse_code=inv_code))
+    extra_loss = float(loss_function(tensors, m, n, code, pic, WithExtra(k=1), inverse_code=inv_code))
+
+    assert abs(extra_loss - base_loss - 7.0) < 1e-10
+
+
+def test_mseloss_extra_loss_uses_tensors():
+    @dataclass(frozen=True)
+    class TensorSum(MSELoss):
+        def _extra_loss(self, tensors):
+            return sum(jnp.sum(jnp.abs(t) ** 2) for t in tensors).real
+
+    m, n = 2, 2
+    code, tensors = qft_code(m, n)
+    inv_code, _ = qft_code(m, n, inverse=True)
+    pic = jnp.zeros((4, 4), dtype=jnp.complex128)
+
+    loss_val = float(loss_function(tensors, m, n, code, pic, TensorSum(k=1), inverse_code=inv_code))
+    expected_reg = float(sum(jnp.sum(jnp.abs(t) ** 2) for t in tensors).real)
+
+    assert abs(loss_val - expected_reg) < 1e-6


### PR DESCRIPTION
## Summary

Adds an optional `_extra_loss(tensors)` hook for `MSELoss` subclasses. Vanilla `MSELoss` behavior remains unchanged; subclasses can opt in to add regularizers or auxiliary scalar terms on top of the existing top-k reconstruction MSE.

Closes #17.

## Validation

- `/opt/conda/envs/pdft/bin/python -m ruff check src/pdft/loss.py tests/test_loss.py`
- `/opt/conda/envs/pdft/bin/python -m pytest tests/test_loss.py -v`
- `/opt/conda/envs/pdft/bin/python -m pytest tests/ -x -q` (`209 passed`)