### PR TITLE
DCT-IV learnable cosine basis (DCT4Basis)

### DIFF
--- a/src/pdft/__init__.py
+++ b/src/pdft/__init__.py
@@ -49,6 +49,7 @@ __upstream_ref__ = "nzy1997/ParametricDFT.jl@a201a27e47df2f0f3ab460f83d49b6e5f5d
 from .bases import (  # noqa: E402
     AbstractSparseBasis,
     BlockedBasis,
+    DCT4Basis,
     EntangledQFTBasis,
     MERABasis,
     QFTBasis,
@@ -66,6 +67,7 @@ __all__ = [
     "AbstractLoss",
     "AbstractSparseBasis",
     "BlockedBasis",
+    "DCT4Basis",
     "EntangledQFTBasis",
     "L1Norm",
     "MERABasis",

--- a/src/pdft/bases/__init__.py
+++ b/src/pdft/bases/__init__.py
@@ -11,6 +11,7 @@ The abstract base class and bases_allclose helper live in bases.base.
 
 from .base import (
     AbstractSparseBasis,
+    DCT4Basis,
     EntangledQFTBasis,
     MERABasis,
     QFTBasis,
@@ -34,6 +35,7 @@ from .circuit import (
 __all__ = [
     "AbstractSparseBasis",
     "BlockedBasis",
+    "DCT4Basis",
     "EntangledQFTBasis",
     "MERABasis",
     "QFTBasis",

--- a/src/pdft/bases/base.py
+++ b/src/pdft/bases/base.py
@@ -468,3 +468,105 @@ def _mera_unflatten(aux, leaves) -> MERABasis:
 
 
 tree_util.register_pytree_node(MERABasis, _mera_flatten, _mera_unflatten)
+
+
+# ---------------------------------------------------------------------------
+# DCT4Basis
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DCT4Basis:
+    """DCT-IV tensor-network basis: the real-orthogonal, ancilla-free analogue
+    of :class:`QFTBasis`.
+
+    Mirrors QFTBasis (one tensor list; `inverse_transform` applies
+    `conj(tensors)` through `inv_code`). The gates are emitted by
+    :func:`pdft.bases.circuit.dct4.dct4_code`; at initialization the forward
+    operator is the bit-reversed orthonormal DCT-IV per dimension, and — since
+    DCT-IV is self-inverse — the basis reconstructs exactly. ``tensors`` holds
+    only the learnable bulk (the affine ``R_y`` rotation layer and the branch
+    Hadamards); the structural mirror-``Q`` CNOT permutations and the ``Delta``
+    sign are emitted ``trainable=False`` and stay fixed. The gate tensors are
+    real-valued (stored complex128, zero imaginary), so the existing unitary
+    manifold trains the real-orthogonal subset under a real objective.
+
+    Pytree contract:
+        leaves   = tensors
+        aux data = (m, n, len(tensors), code, inv_code)
+    """
+
+    m: int
+    n: int
+    tensors: list[Array]
+    code: object = field(compare=False, repr=False)
+    inv_code: object = field(compare=False, repr=False)
+
+    def __init__(
+        self,
+        m: int,
+        n: int,
+        tensors: Sequence[Array] | None = None,
+        code: object | None = None,
+        inv_code: object | None = None,
+    ):
+        if m < 1 or n < 1:
+            raise ValueError(f"m and n must be >= 1, got m={m}, n={n}")
+        from .circuit.dct4 import dct4_code
+
+        self.m = m
+        self.n = n
+        _code, init_tensors = dct4_code(m, n)
+        _inv_code, _ = dct4_code(m, n, inverse=True)
+        self.tensors = list(tensors) if tensors is not None else init_tensors
+        self.code = code if code is not None else _code
+        self.inv_code = inv_code if inv_code is not None else _inv_code
+
+    @property
+    def inv_tensors(self) -> list[Array]:
+        return self.tensors
+
+    @property
+    def image_size(self) -> tuple[int, int]:
+        return (2**self.m, 2**self.n)
+
+    @property
+    def num_parameters(self) -> int:
+        return sum(int(t.size) for t in self.tensors)
+
+    def forward_transform(self, pic: Array) -> Array:
+        from .circuit.dct4 import dct4_ft_mat
+
+        return dct4_ft_mat(self.tensors, self.code, self.m, self.n, pic)
+
+    def inverse_transform(self, pic: Array) -> Array:
+        from .circuit.dct4 import dct4_ift_mat
+
+        return dct4_ift_mat(
+            [jnp.conj(t) for t in self.tensors],
+            self.inv_code,
+            self.m,
+            self.n,
+            pic,
+        )
+
+
+def _dct4basis_flatten(b: DCT4Basis):
+    leaves = tuple(b.tensors)
+    aux = (b.m, b.n, len(b.tensors), b.code, b.inv_code)
+    return leaves, aux
+
+
+def _dct4basis_unflatten(aux, leaves) -> DCT4Basis:
+    m, n, n_fwd, code, inv_code = aux
+    assert len(leaves) == n_fwd
+    out = DCT4Basis.__new__(DCT4Basis)
+    out.m = m
+    out.n = n
+    out.tensors = list(leaves)
+    out.code = code
+    out.inv_code = inv_code
+    return out
+
+
+tree_util.register_pytree_node(DCT4Basis, _dct4basis_flatten, _dct4basis_unflatten)

--- a/src/pdft/bases/circuit/__init__.py
+++ b/src/pdft/bases/circuit/__init__.py
@@ -1,10 +1,11 @@
-"""Circuit-topology bases: QFT, EntangledQFT, TEBD, MERA, Rich, RealRich.
+"""Circuit-topology bases: QFT, DCT-IV, EntangledQFT, TEBD, MERA, Rich, RealRich.
 
 Rich/RealRich are H + U(4) circuits on the QFT topology — full-image
 transforms usable standalone or as a BlockedBasis inner.
 """
 
 from .qft import ft_mat, ift_mat, qft_code
+from .dct4 import dct4_code, dct4_ft_mat, dct4_ift_mat
 from .entangled_qft import entangled_qft_code
 from .mera import mera_code
 from .tebd import tebd_code
@@ -15,6 +16,9 @@ from .freeze import freeze_as_blocked
 __all__ = [
     "RealRichBasis",
     "RichBasis",
+    "dct4_code",
+    "dct4_ft_mat",
+    "dct4_ift_mat",
     "entangled_qft_code",
     "fit_to_dct",
     "freeze_as_blocked",

--- a/src/pdft/bases/circuit/dct4.py
+++ b/src/pdft/bases/circuit/dct4.py
@@ -1,0 +1,151 @@
+"""DCT-IV circuit as a hand-rolled tensor network.
+
+Real-orthogonal analogue of the QFT (cf. :mod:`pdft.bases.circuit.qft`). The
+DCT-IV is the self-dual "bulk" cosine transform: real, orthogonal, and its
+own inverse. Unlike the DCT-II it is **ancilla-free** and uses only 1- and
+2-qubit gates, so it drops straight into the H + 2-qubit-gate tensor-network
+builder with no multi-controlled scaffolding.
+
+The 1D recursion (uniform: same child on both halves), for N = 2M:
+
+    C^IV_{2M} = (H layer)(Z sign)(I_2 (x) C^IV_M)(R_y layer)(mirror Q)
+
+Per level k on the within-block qubits (b = top qubit of the level):
+
+    * mirror Q      : CX(control=b, target=q) for q below b
+    * rotation T    : R_y(pi / 2N) on b, then CR_y(pi 2^p / N) on b
+                      controlled by each lower bit (affine-angle decomposition
+                      -> one base rotation + one controlled rotation per bit,
+                      never a 2^m multiplexer)
+    * recurse       : C^IV_M on the lower register (uncontrolled)
+    * Z sign Delta  : CZ(control=b, target=next qubit)
+    * H merge       : H on b
+
+All angles are fixed by the transform at initialization. The trainable leaves
+are the *bulk* gates — the affine ``R_y`` rotation layer and the branch
+Hadamards (the real-orthogonal degrees of freedom; cf. the relaxation in
+``all_real_dct_zero_ancilla.tex``). The structural gates — the mirror-``Q``
+CNOT permutations and the ``Delta`` sign — are emitted ``trainable=False``, so
+they stay fixed wiring and never enter the optimizer. The forward operator
+equals the bit-reversed orthonormal DCT-IV per dimension, matching the
+bit-reversed output convention of :func:`qft_code`.
+
+2D DCT-IV = (m-qubit DCT-IV on row qubits) tensor (n-qubit DCT-IV on col
+qubits); no entanglement between blocks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from ...circuit.builder import (
+    HADAMARD,
+    Gate,
+    apply_circuit,
+    compile_circuit,
+    controlled_phase_diag,
+)
+
+Array = jax.Array
+
+
+__all__ = [
+    "dct4_code",
+    "dct4_ft_mat",
+    "dct4_ift_mat",
+    "_dct4_gates_1d",
+]
+
+
+def _ry(theta: float) -> Array:
+    """Single-qubit real R_y(theta) as a (2, 2) complex tensor `T[out, in]`."""
+    c, s = np.cos(theta / 2.0), np.sin(theta / 2.0)
+    return jnp.asarray(np.array([[c, -s], [s, c]]), dtype=jnp.complex128)
+
+
+def _cnot_u4() -> Array:
+    """CNOT as a (2, 2, 2, 2) tensor `T[out_ctrl, out_tgt, in_ctrl, in_tgt]`."""
+    M = np.zeros((2, 2, 2, 2))
+    for ic in (0, 1):
+        for it in (0, 1):
+            M[ic, it ^ ic, ic, it] = 1.0
+    return jnp.asarray(M, dtype=jnp.complex128)
+
+
+def _cry_u4(theta: float) -> Array:
+    """Controlled-R_y(theta) as a (2, 2, 2, 2) tensor (control fires on 1)."""
+    c, s = np.cos(theta / 2.0), np.sin(theta / 2.0)
+    R = np.array([[c, -s], [s, c]])
+    M = np.zeros((2, 2, 2, 2))
+    for it in (0, 1):
+        M[0, it, 0, it] = 1.0  # control = 0 -> identity on target
+    for ot in (0, 1):
+        for it in (0, 1):
+            M[1, ot, 1, it] = R[ot, it]  # control = 1 -> R_y on target
+    return jnp.asarray(M, dtype=jnp.complex128)
+
+
+def _dct4_gates_1d(n_qubits: int, offset: int) -> list[Gate]:
+    """Emit the 1D DCT-IV gate sequence on qubits (offset+1, ..., offset+n_qubits).
+
+    Within-block qubit ``q`` (0 = top/most significant) maps to builder qubit
+    ``offset + n_qubits - q`` (Yao little-endian), which reproduces the
+    bit-reversed orthonormal DCT-IV exactly.
+    """
+
+    def Q(q: int) -> int:
+        return offset + n_qubits - q
+
+    gates: list[Gate] = []
+
+    def level(k: int) -> None:
+        if k == n_qubits:
+            return
+        size = 2 ** (n_qubits - k)
+        b = k
+        lower = list(range(k + 1, n_qubits))
+        # mirror Q: controlled bit-complement of the lower register (structural
+        # permutation — fixed, not a learnable degree of freedom)
+        for q in lower:
+            gates.append(Gate(kind="U4", qubits=(Q(b), Q(q)), tensor=_cnot_u4(), phase=0.0, trainable=False))
+        # rotation layer T (affine angles) — the learnable real-orthogonal bulk
+        gates.append(Gate(kind="H", qubits=(Q(b),), tensor=_ry(np.pi / (2 * size)), phase=0.0))
+        for p in range(n_qubits - 1 - k):
+            theta = np.pi * (2**p) / size
+            gates.append(Gate(kind="U4", qubits=(Q(n_qubits - 1 - p), Q(b)), tensor=_cry_u4(theta), phase=0.0))
+        # mirror Q again (structural — fixed)
+        for q in lower:
+            gates.append(Gate(kind="U4", qubits=(Q(b), Q(q)), tensor=_cnot_u4(), phase=0.0, trainable=False))
+        # recurse on the lower register (uncontrolled)
+        level(k + 1)
+        # Z sign (Delta, fixed) + learnable branch Hadamard merge
+        if lower:
+            gates.append(
+                Gate(kind="CP", qubits=(Q(b), Q(k + 1)), tensor=controlled_phase_diag(float(np.pi)), phase=float(np.pi), trainable=False)
+            )
+        gates.append(Gate(kind="H", qubits=(Q(b),), tensor=HADAMARD, phase=0.0))
+
+    level(0)
+    return gates
+
+
+def dct4_code(m: int, n: int, *, inverse: bool = False) -> tuple[Callable[..., Array], list[Array]]:
+    """Return `(einsum_fn, initial_tensors)` for 2D DCT-IV on (2^m, 2^n) images."""
+    if m < 1 or n < 1:
+        raise ValueError(f"m and n must be >= 1, got m={m}, n={n}")
+    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+    return compile_circuit(gates, m, n, inverse=inverse)
+
+
+def dct4_ft_mat(tensors: list[Array], code: Callable, m: int, n: int, pic: Array) -> Array:
+    """Apply 2D DCT-IV circuit to a (2^m, 2^n) image."""
+    return apply_circuit(tensors, code, m, n, pic)
+
+
+def dct4_ift_mat(tensors: list[Array], code: Callable, m: int, n: int, pic: Array) -> Array:
+    """Apply 2D inverse DCT-IV circuit. Caller must have conjugated the tensors."""
+    return apply_circuit(tensors, code, m, n, pic)

--- a/tests/bases/circuit/test_dct4.py
+++ b/tests/bases/circuit/test_dct4.py
@@ -1,0 +1,116 @@
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from scipy.fft import dct
+
+from pdft.bases.base import DCT4Basis
+from pdft.bases.circuit.dct4 import (
+    _cnot_u4,
+    _cry_u4,
+    _dct4_gates_1d,
+    _ry,
+    dct4_code,
+    dct4_ft_mat,
+    dct4_ift_mat,
+)
+
+
+def _bitrev_perm(n_qubits: int) -> np.ndarray:
+    """Bit-reversal permutation matrix on 2**n_qubits indices."""
+    size = 2**n_qubits
+    P = np.zeros((size, size))
+    for i in range(size):
+        r = int(format(i, f"0{n_qubits}b")[::-1], 2)
+        P[r, i] = 1.0
+    return P
+
+
+def _dct4_op(n_qubits: int) -> np.ndarray:
+    """Expected 1D forward operator: bit-reversed orthonormal DCT-IV."""
+    size = 2**n_qubits
+    D4 = dct(np.eye(size), type=4, norm="ortho", axis=0)
+    return _bitrev_perm(n_qubits) @ D4
+
+
+# ---------- gate tensors ----------
+
+
+def test_ry_is_real_orthogonal():
+    R = np.asarray(_ry(0.7))
+    assert np.allclose(R.imag, 0.0, atol=1e-15)
+    assert np.allclose(R @ R.T, np.eye(2), atol=1e-12)
+
+
+def test_cnot_u4_structure():
+    M = np.asarray(_cnot_u4()).reshape(4, 4)  # [oc ot, ic it]
+    expected = np.array([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]])
+    assert np.allclose(M, expected, atol=1e-12)
+
+
+def test_cry_u4_control_blocks():
+    theta = 0.9
+    M = np.asarray(_cry_u4(theta)).reshape(4, 4)  # rows (oc,ot), cols (ic,it)
+    # control preserved: block-diag(I on target | R_y(theta) on target)
+    Ry = np.asarray(_ry(theta))
+    expected = np.block([[np.eye(2), np.zeros((2, 2))], [np.zeros((2, 2)), Ry]])
+    assert np.allclose(M, expected, atol=1e-12)
+
+
+# ---------- code-level ----------
+
+
+def test_dct4_code_returns_callable_and_tensors():
+    code, tensors = dct4_code(2, 2)
+    assert callable(code)
+    assert len(tensors) > 0
+
+
+def test_dct4_code_rejects_bad_dimensions():
+    with pytest.raises(ValueError):
+        dct4_code(0, 1)
+    with pytest.raises(ValueError):
+        dct4_code(1, 0)
+
+
+def test_dct4_forward_matches_bitreversed_dct_iv():
+    # Defining property: per dimension the circuit equals the bit-reversed
+    # orthonormal DCT-IV (matching qft_code's bit-reversed output order).
+    for m, n in [(1, 2), (2, 2), (2, 3), (3, 3)]:
+        code, tensors = dct4_code(m, n)
+        Rm, Rn = _dct4_op(m), _dct4_op(n)
+        rng = np.random.default_rng(m * 10 + n)
+        pic = rng.standard_normal((2**m, 2**n))
+        out = np.asarray(dct4_ft_mat(tensors, code, m, n, jnp.asarray(pic, jnp.complex128)))
+        assert np.allclose(out.imag, 0.0, atol=1e-12)
+        assert np.allclose(out.real, Rm @ pic @ Rn.T, atol=1e-12)
+
+
+def test_dct4_ft_ift_roundtrip():
+    m, n = 2, 3
+    code_fwd, tensors = dct4_code(m, n)
+    code_inv, _ = dct4_code(m, n, inverse=True)
+    rng = np.random.default_rng(0)
+    pic = jnp.asarray(rng.standard_normal((2**m, 2**n)), jnp.complex128)
+    fwd = dct4_ft_mat(tensors, code_fwd, m, n, pic)
+    rec = dct4_ift_mat([jnp.conj(t) for t in tensors], code_inv, m, n, fwd)
+    assert jnp.allclose(rec, pic, atol=1e-10)
+
+
+# ---------- basis class ----------
+
+
+def test_dct4_basis_roundtrip_and_real():
+    for m, n in [(2, 3), (3, 3), (4, 4)]:
+        b = DCT4Basis(m, n)
+        rng = np.random.default_rng(m + n)
+        pic = jnp.asarray(rng.standard_normal((2**m, 2**n)), jnp.complex128)
+        fwd = b.forward_transform(pic)
+        assert np.allclose(np.asarray(fwd).imag, 0.0, atol=1e-12)
+        rec = b.inverse_transform(fwd)
+        assert jnp.allclose(rec, pic, atol=1e-10)
+
+
+def test_dct4_gates_are_at_most_two_qubit():
+    gates = _dct4_gates_1d(4, offset=0)
+    assert all(len(g["qubits"]) <= 2 for g in gates)
+    assert {g["kind"] for g in gates} <= {"H", "CP", "U4"}


### PR DESCRIPTION
## Summary

Adds the ancilla-free **DCT-IV** learnable cosine basis (`DCT4Basis`) on top of the stock framework — **no builder, block, or ancilla changes**. `dct4_code` emits only `H` / `CP` / `U4` gates the circuit builder already supports; at init the forward operator is the bit-reversed orthonormal DCT-IV per dimension, and since DCT-IV is self-inverse the basis reconstructs exactly, then relaxes under Riemannian Adam (real-orthogonal subgroup).

6 files, **+378 / −1**:
- `src/pdft/bases/circuit/dct4.py` — gate emitter + ft/ift closures
- `DCT4Basis` in `bases/base.py` — QFTBasis-style pytree wrapper
- `DCT4Basis` / `dct4_code` re-exports in the three `__init__.py`
- `tests/bases/circuit/test_dct4.py`

## Verification

- **238 tests pass**, coverage **91.35%**.
- Operator parity: forward `==` `scipy.fft.dct(type=4, norm="ortho")` bit-reversed (`~2e-16`); output real (`~1e-16`); ft/ift roundtrip exact; gates ≤ 2-qubit.

## Benchmark (A800, `generalized`, mean test PSNR dB)

DCT-IV results across the keep-ratio sweep ρ ∈ {0.05, 0.10, 0.15, 0.20}:

**DIV2K-8q**

| basis | 0.05 | 0.10 | 0.15 | 0.20 |
|---|---|---|---|---|
| dct4 (full-image) | 26.36 | 29.07 | 31.17 | 33.01 |
| dct4_8 (block) | 25.72 | 28.90 | 31.28 | 33.36 |
| *ref:* DCT / RealRich-8 / BlockDCT-8 | 25.36 / 26.00 / 26.11 | … | … | 30.85 / 33.69 / 34.01 |

**Quick Draw**

| basis | 0.05 | 0.10 | 0.15 | 0.20 |
|---|---|---|---|---|
| dct4 (full-image) | 18.97 | 23.14 | 26.71 | 29.92 |
| dct4_4 (block, best) | 18.71 | 23.59 | 28.09 | 32.79 |
| *ref:* DCT / RealRich-8 / BlockDCT-8 | 16.13 / 18.79 / 17.20 | … | … | 22.03 / 32.37 / 26.63 |

Full-image `dct4` is the strongest full-image basis (+2.1 dB over DCT/QFT on DIV2K, +7.9 dB over fixed DCT on Quick Draw at ρ=0.20). Block-wrapped `dct4` is competitive with rich/real_rich and beats fixed BlockDCT by +6 dB on Quick Draw.

> Registry entries land in the companion `pdft-benchmarks` PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
