### PR TITLE
feat(dct4): structured O(2) twiddle parametrization (avoid dense O(4))

### DIFF
--- a/src/pdft/bases/base.py
+++ b/src/pdft/bases/base.py
@@ -510,6 +510,7 @@ class DCT4Basis:
         tensors: Sequence[Array] | None = None,
         code: object | None = None,
         inv_code: object | None = None,
+        parametrization: str = "o4",
     ):
         if m < 1 or n < 1:
             raise ValueError(f"m and n must be >= 1, got m={m}, n={n}")
@@ -517,8 +518,8 @@ class DCT4Basis:
 
         self.m = m
         self.n = n
-        _code, init_tensors = dct4_code(m, n)
-        _inv_code, _ = dct4_code(m, n, inverse=True)
+        _code, init_tensors = dct4_code(m, n, parametrization=parametrization)
+        _inv_code, _ = dct4_code(m, n, inverse=True, parametrization=parametrization)
         self.tensors = list(tensors) if tensors is not None else init_tensors
         self.code = code if code is not None else _code
         self.inv_code = inv_code if inv_code is not None else _inv_code

--- a/src/pdft/bases/circuit/dct4.py
+++ b/src/pdft/bases/circuit/dct4.py
@@ -66,6 +66,7 @@ __all__ = [
     "dct4_ft_mat",
     "dct4_ift_mat",
     "_dct4_gates_1d",
+    "_cry",
 ]
 
 
@@ -95,6 +96,16 @@ def _cry_u4(theta: float) -> Array:
         for it in (0, 1):
             M[1, ot, 1, it] = R[ot, it]  # control = 1 -> R_y on target
     return jnp.asarray(M, dtype=jnp.complex128)
+
+
+def _cry(theta: float) -> Array:
+    """Controlled-R_y trainable leaf: just the (2, 2) R_y block.
+
+    Applied with control structure by the builder's ``CRY`` kind (identity on
+    control = 0, this block on control = 1), so the leaf trains on O(2) — the
+    structured, dense-O(4)-free parametrization of the twiddle.
+    """
+    return _ry(theta)
 
 
 def _dct4_gates_1d(n_qubits: int, offset: int) -> list[Gate]:

--- a/src/pdft/bases/circuit/dct4.py
+++ b/src/pdft/bases/circuit/dct4.py
@@ -108,7 +108,7 @@ def _cry(theta: float) -> Array:
     return _ry(theta)
 
 
-def _dct4_gates_1d(n_qubits: int, offset: int) -> list[Gate]:
+def _dct4_gates_1d(n_qubits: int, offset: int, parametrization: str = "o4") -> list[Gate]:
     """Emit the 1D DCT-IV gate sequence on qubits (offset+1, ..., offset+n_qubits).
 
     Within-block qubit ``q`` (0 = top/most significant) maps to builder qubit
@@ -135,7 +135,12 @@ def _dct4_gates_1d(n_qubits: int, offset: int) -> list[Gate]:
         gates.append(Gate(kind="H", qubits=(Q(b),), tensor=_ry(np.pi / (2 * size)), phase=0.0))
         for p in range(n_qubits - 1 - k):
             theta = np.pi * (2**p) / size
-            gates.append(Gate(kind="U4", qubits=(Q(n_qubits - 1 - p), Q(b)), tensor=_cry_u4(theta), phase=0.0))
+            if parametrization == "controlled":
+                gates.append(Gate(kind="CRY", qubits=(Q(n_qubits - 1 - p), Q(b)),
+                                  tensor=_cry(theta), phase=0.0))
+            else:
+                gates.append(Gate(kind="U4", qubits=(Q(n_qubits - 1 - p), Q(b)),
+                                  tensor=_cry_u4(theta), phase=0.0))
         # R: odd-branch reversal — the mirror-Q permutation repeated
         for q in lower:
             gates.append(Gate(kind="U4", qubits=(Q(b), Q(q)), tensor=_cnot_u4(), phase=0.0))
@@ -152,11 +157,25 @@ def _dct4_gates_1d(n_qubits: int, offset: int) -> list[Gate]:
     return gates
 
 
-def dct4_code(m: int, n: int, *, inverse: bool = False) -> tuple[Callable[..., Array], list[Array]]:
-    """Return `(einsum_fn, initial_tensors)` for 2D DCT-IV on (2^m, 2^n) images."""
+def dct4_code(
+    m: int, n: int, *, inverse: bool = False, parametrization: str = "o4"
+) -> tuple[Callable[..., Array], list[Array]]:
+    """Return `(einsum_fn, initial_tensors)` for 2D DCT-IV on (2^m, 2^n) images.
+
+    ``parametrization`` selects how the affine twiddle is stored: ``"o4"``
+    (default) emits a dense ``(2, 2, 2, 2)`` controlled-R_y trained on O(4);
+    ``"controlled"`` emits a single-angle ``CRY`` gate whose trainable leaf is
+    a ``(2, 2)`` block on O(2) (the mirror-Q CNOTs stay dense U4).
+    """
     if m < 1 or n < 1:
         raise ValueError(f"m and n must be >= 1, got m={m}, n={n}")
-    gates = _dct4_gates_1d(m, offset=0) + _dct4_gates_1d(n, offset=m)
+    if parametrization not in ("o4", "controlled"):
+        raise ValueError(
+            f"parametrization must be 'o4' or 'controlled', got {parametrization!r}"
+        )
+    gates = _dct4_gates_1d(m, offset=0, parametrization=parametrization) + _dct4_gates_1d(
+        n, offset=m, parametrization=parametrization
+    )
     return compile_circuit(gates, m, n, inverse=inverse)
 
 

--- a/src/pdft/circuit/builder.py
+++ b/src/pdft/circuit/builder.py
@@ -43,7 +43,7 @@ def controlled_phase_diag(phi: float) -> Array:
 
 
 class Gate(TypedDict):
-    kind: str  # "H", "CP", or "U4"
+    kind: str  # "H", "CP", "U4", or "CRY"
     qubits: tuple[int, ...]
     tensor: Array
     phase: float
@@ -267,6 +267,21 @@ def _stepped_apply(
             contract_axes = [[0, 1], [ax_c, ax_t]] if inverse else [[2, 3], [ax_c, ax_t]]
             pic = jnp.tensordot(T, pic, axes=contract_axes)
             pic = jnp.moveaxis(pic, [0, 1], [ax_c, ax_t])
+        elif kind == "CRY":
+            # Controlled rotation: T is a (2, 2) block applied to the target
+            # on the control = 1 branch only (control passes through). Same
+            # forward/inverse leg convention as the H handler; the caller
+            # conjugates tensors for the true adjoint on the inverse path.
+            q_ctrl, q_tgt = qubits
+            ax_c = _axis_of_qubit(q_ctrl, m, n)
+            ax_t = _axis_of_qubit(q_tgt, m, n)
+            contract_in = 0 if inverse else 1
+            applied = jnp.tensordot(T, pic, axes=[[contract_in], [ax_t]])
+            applied = jnp.moveaxis(applied, 0, ax_t)
+            sel_shape = [1] * pic.ndim
+            sel_shape[ax_c] = 2
+            ctrl1 = jnp.asarray([False, True]).reshape(sel_shape)
+            pic = jnp.where(ctrl1, applied, pic)
         else:
             raise AssertionError(f"unknown gate kind: {kind}")
     return pic

--- a/src/pdft/circuit/builder.py
+++ b/src/pdft/circuit/builder.py
@@ -271,19 +271,26 @@ def _stepped_apply(
             pic = jnp.moveaxis(pic, [0, 1], [ax_c, ax_t])
         elif kind == "CRY":
             # Controlled rotation: T is a (2, 2) block applied to the target
-            # on the control = 1 branch only (control passes through). Same
-            # forward/inverse leg convention as the H handler; the caller
-            # conjugates tensors for the true adjoint on the inverse path.
+            # on the control = 1 branch only (control passes through). Apply
+            # the block to the control = 1 half *only*: slicing the control
+            # axis touches 2**(m+n-1) amplitudes and recombines, instead of
+            # rotating the whole state and discarding the control = 0 half via
+            # a full-size jnp.where mask (which both doubled the contraction
+            # and materialised a 2**(m+n) masked intermediate per step — the
+            # dominant cost at large registers). Same forward/inverse leg
+            # convention as the H handler; the caller conjugates tensors for
+            # the true adjoint on the inverse path.
             q_ctrl, q_tgt = qubits
             ax_c = _axis_of_qubit(q_ctrl, m, n)
             ax_t = _axis_of_qubit(q_tgt, m, n)
             contract_in = 0 if inverse else 1
-            applied = jnp.tensordot(T, pic, axes=[[contract_in], [ax_t]])
-            applied = jnp.moveaxis(applied, 0, ax_t)
-            sel_shape = [1] * pic.ndim
-            sel_shape[ax_c] = 2
-            ctrl1 = jnp.asarray([False, True]).reshape(sel_shape)
-            pic = jnp.where(ctrl1, applied, pic)
+            pic0 = jnp.take(pic, 0, axis=ax_c)  # control = 0 (passthrough)
+            pic1 = jnp.take(pic, 1, axis=ax_c)  # control = 1 (rotated)
+            # target axis index after the control axis is sliced out
+            ax_t1 = ax_t if ax_t < ax_c else ax_t - 1
+            rot = jnp.tensordot(T, pic1, axes=[[contract_in], [ax_t1]])
+            rot = jnp.moveaxis(rot, 0, ax_t1)
+            pic = jnp.stack([pic0, rot], axis=ax_c)
         else:
             raise AssertionError(f"unknown gate kind: {kind}")
     return pic

--- a/src/pdft/circuit/builder.py
+++ b/src/pdft/circuit/builder.py
@@ -157,6 +157,8 @@ def build_circuit_einsum(
             wire_state[q_ctrl] = out_c
             wire_state[q_tgt] = out_t
         else:
+            # NOTE: "CRY" is handled only by the stepped path (_stepped_apply);
+            # the legacy einsum builder does not emit it.
             raise AssertionError(f"unknown gate kind: {g['kind']}")
 
     # Hadamard-first sort (matches Julia's perm_vec).

--- a/tests/bases/circuit/test_dct4.py
+++ b/tests/bases/circuit/test_dct4.py
@@ -145,7 +145,10 @@ def test_controlled_drops_twiddle_o4_gates():
     m, n = 3, 3
     b_o4 = DCT4Basis(m, n)
     b_ctl = DCT4Basis(m, n, parametrization="controlled")
-    n4 = lambda b: sum(1 for t in b.tensors if t.shape == (2, 2, 2, 2))
+
+    def n4(b):
+        return sum(1 for t in b.tensors if t.shape == (2, 2, 2, 2))
+
     assert n4(b_o4) - n4(b_ctl) == 6
 
 

--- a/tests/bases/circuit/test_dct4.py
+++ b/tests/bases/circuit/test_dct4.py
@@ -117,14 +117,12 @@ def test_dct4_gates_are_at_most_two_qubit():
 
 
 def _rand_pic_c(m, n, seed=1):
-    import jax.numpy as jnp
     rng = np.random.default_rng(seed)
     a = rng.standard_normal((2**m, 2**n)) + 1j * rng.standard_normal((2**m, 2**n))
     return jnp.asarray(a, dtype=jnp.complex128)
 
 
 def test_controlled_matches_o4_at_init():
-    import jax.numpy as jnp
     m, n = 3, 3
     pic = _rand_pic_c(m, n)
     b_o4 = DCT4Basis(m, n)
@@ -135,7 +133,6 @@ def test_controlled_matches_o4_at_init():
 
 
 def test_controlled_roundtrips():
-    import jax.numpy as jnp
     m, n = 3, 2
     pic = _rand_pic_c(m, n)
     b = DCT4Basis(m, n, parametrization="controlled")
@@ -166,7 +163,6 @@ def test_controlled_twiddle_on_o2_manifold():
 
 def test_controlled_gradient_flows_to_2x2_leaves():
     import jax
-    import jax.numpy as jnp
     m, n = 2, 2
     pic = _rand_pic_c(m, n)
     b = DCT4Basis(m, n, parametrization="controlled")
@@ -177,5 +173,11 @@ def test_controlled_gradient_flows_to_2x2_leaves():
         return jnp.sum((jnp.abs(out) ** 2) * w)
 
     grads = jax.grad(loss)(b.tensors)
-    two_grads = [g for g, t in zip(grads, b.tensors) if t.shape == (2, 2)]
-    assert two_grads and any(float(jnp.max(jnp.abs(g))) > 1e-8 for g in two_grads)
+    from pdft.bases.circuit.dct4 import _dct4_gates_1d
+    from pdft.circuit.builder import sorted_gate_program
+    gates = (_dct4_gates_1d(m, offset=0, parametrization="controlled")
+             + _dct4_gates_1d(n, offset=m, parametrization="controlled"))
+    program = sorted_gate_program(gates)
+    cry_idx = [i for i, (kind, _q) in enumerate(program) if kind == "CRY"]
+    assert cry_idx, "expected CRY twiddle leaves in the controlled parametrization"
+    assert all(float(jnp.max(jnp.abs(grads[i]))) > 1e-8 for i in cry_idx)

--- a/tests/bases/circuit/test_dct4.py
+++ b/tests/bases/circuit/test_dct4.py
@@ -114,3 +114,68 @@ def test_dct4_gates_are_at_most_two_qubit():
     gates = _dct4_gates_1d(4, offset=0)
     assert all(len(g["qubits"]) <= 2 for g in gates)
     assert {g["kind"] for g in gates} <= {"H", "CP", "U4"}
+
+
+def _rand_pic_c(m, n, seed=1):
+    import jax.numpy as jnp
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal((2**m, 2**n)) + 1j * rng.standard_normal((2**m, 2**n))
+    return jnp.asarray(a, dtype=jnp.complex128)
+
+
+def test_controlled_matches_o4_at_init():
+    import jax.numpy as jnp
+    m, n = 3, 3
+    pic = _rand_pic_c(m, n)
+    b_o4 = DCT4Basis(m, n)
+    b_ctl = DCT4Basis(m, n, parametrization="controlled")
+    out_o4 = dct4_ft_mat(b_o4.tensors, b_o4.code, m, n, pic)
+    out_ctl = dct4_ft_mat(b_ctl.tensors, b_ctl.code, m, n, pic)
+    assert jnp.allclose(out_o4, out_ctl, atol=1e-10)
+
+
+def test_controlled_roundtrips():
+    import jax.numpy as jnp
+    m, n = 3, 2
+    pic = _rand_pic_c(m, n)
+    b = DCT4Basis(m, n, parametrization="controlled")
+    fwd = b.forward_transform(pic)
+    back = b.inverse_transform(fwd)
+    assert jnp.allclose(back, pic, atol=1e-9)
+
+
+def test_controlled_drops_twiddle_o4_gates():
+    m, n = 3, 3
+    b_o4 = DCT4Basis(m, n)
+    b_ctl = DCT4Basis(m, n, parametrization="controlled")
+    n4 = lambda b: sum(1 for t in b.tensors if t.shape == (2, 2, 2, 2))
+    assert n4(b_o4) - n4(b_ctl) == 6
+
+
+def test_controlled_twiddle_on_o2_manifold():
+    from pdft.manifolds import Unitary2qManifold, group_by_manifold
+    b_o4 = DCT4Basis(3, 3)
+    b_ctl = DCT4Basis(3, 3, parametrization="controlled")
+
+    def n_o4(b):
+        g = group_by_manifold(list(b.tensors))
+        return sum(len(v) for k, v in g.items() if isinstance(k, Unitary2qManifold))
+
+    assert n_o4(b_o4) - n_o4(b_ctl) == 6
+
+
+def test_controlled_gradient_flows_to_2x2_leaves():
+    import jax
+    import jax.numpy as jnp
+    m, n = 2, 2
+    pic = _rand_pic_c(m, n)
+    b = DCT4Basis(m, n, parametrization="controlled")
+    w = jnp.arange(2 ** (m + n), dtype=jnp.float64).reshape((2**m, 2**n))
+
+    def loss(tensors):
+        out = dct4_ft_mat(tensors, b.code, m, n, pic)
+        return jnp.sum((jnp.abs(out) ** 2) * w)
+
+    grads = jax.grad(loss)(b.tensors)
+    two_grads = [g for g, t in zip(grads, b.tensors) if t.shape == (2, 2)]
+    assert two_grads and any(float(jnp.max(jnp.abs(g))) > 1e-8 for g in two_grads)

--- a/tests/circuit/test_cry_gate.py
+++ b/tests/circuit/test_cry_gate.py
@@ -1,0 +1,38 @@
+import jax.numpy as jnp
+import numpy as np
+
+from pdft.bases.circuit.dct4 import _cry_u4, _ry
+from pdft.circuit.builder import Gate, apply_circuit, compile_circuit
+
+
+def _rand_pic(m, n, seed=0):
+    rng = np.random.default_rng(seed)
+    a = rng.standard_normal((2**m, 2**n)) + 1j * rng.standard_normal((2**m, 2**n))
+    return jnp.asarray(a, dtype=jnp.complex128)
+
+
+def test_cry_matches_cry_u4_forward():
+    """A CRY gate (2x2 leaf, applied controlled) equals the dense U4 CR_y."""
+    theta = 0.37
+    m, n = 1, 1  # qubit 1 = control, qubit 2 = target
+    pic = _rand_pic(m, n)
+    code_cry, t_cry = compile_circuit(
+        [Gate(kind="CRY", qubits=(1, 2), tensor=_ry(theta), phase=0.0)], m, n, inverse=False)
+    code_u4, t_u4 = compile_circuit(
+        [Gate(kind="U4", qubits=(1, 2), tensor=_cry_u4(theta), phase=0.0)], m, n, inverse=False)
+    out_cry = apply_circuit(t_cry, code_cry, m, n, pic)
+    out_u4 = apply_circuit(t_u4, code_u4, m, n, pic)
+    assert jnp.allclose(out_cry, out_u4, atol=1e-10)
+
+
+def test_cry_roundtrip_identity():
+    """forward then inverse (with real R_y) reconstructs the input."""
+    theta = 0.81
+    m, n = 1, 2
+    pic = _rand_pic(m, n)
+    gates = [Gate(kind="CRY", qubits=(1, 3), tensor=_ry(theta), phase=0.0)]
+    code_f, tf = compile_circuit(gates, m, n, inverse=False)
+    code_i, ti = compile_circuit(gates, m, n, inverse=True)
+    fwd = apply_circuit(tf, code_f, m, n, pic)
+    back = apply_circuit([jnp.conj(t) for t in ti], code_i, m, n, fwd)
+    assert jnp.allclose(back, pic, atol=1e-10)


### PR DESCRIPTION
## Summary

Adds a structured, dense-O(4)-free parametrization of the DCT-IV circuit.

- **New `CRY` gate kind** (`circuit/builder.py`): a `(2,2)` rotation leaf applied to the target on the **control=1 branch only** (control passes through). Because the trainable leaf is `(2,2)`, `classify_manifold` auto-selects **O(2)** (a single angle) instead of dense **O(4)**. Same forward/inverse leg convention as the `H` handler.
- **`DCT4Basis(..., parametrization="controlled")`** (`bases/circuit/dct4.py`, `bases/base.py`): emits the affine twiddle (`T`) as `CRY` `(2,2)` leaves; the mirror `Q`/`R` CNOTs stay `U4` (intended to be frozen as fixed routing at train time). Reproduces the exact bit-reversed orthonormal DCT-IV at init and round-trips.
- **Default `parametrization="o4"` is byte-identical** to prior behavior.

Motivation: profiling showed the dense-O(4) relaxation of all 168 two-qubit gates is the cost driver of DCT-IV training; this gives the twiddle a single-angle O(2) parametrization (mirror frozen) to avoid that.

## Test plan

- [x] `tests/circuit/test_cry_gate.py` — `CRY` matches the dense `U4` CR_y (forward) and round-trips.
- [x] `tests/bases/circuit/test_dct4.py` — controlled == o4 operator at init; round-trips; drops exactly the twiddle O(4) gates; twiddle leaves land on the O(2) manifold; gradient flows to the CRY twiddle leaves specifically.
- [x] Full suite: **245 passed** (default `o4` path unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)